### PR TITLE
Fix missing GraphQL schema path for backend tests

### DIFF
--- a/packages/backend/backend_design_docs/graphql/referral_schema.graphql
+++ b/packages/backend/backend_design_docs/graphql/referral_schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  _placeholder: String
+}


### PR DESCRIPTION
## Summary
- add `backend_design_docs/graphql/referral_schema.graphql` placeholder so AppSync stack tests can read a schema file

## Testing
- `pnpm run backend:test` *(fails: unsupported pnpm version)*

------
https://chatgpt.com/codex/tasks/task_b_68435f023a50832995bf6b51224a5ba6