### PR TITLE
fix auth login when user already signed in

### DIFF
--- a/packages/frontend/src/contexts/AuthContext.tsx
+++ b/packages/frontend/src/contexts/AuthContext.tsx
@@ -68,11 +68,20 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const login = async (email: string, password: string) => {
     setIsLoading(true);
     try {
+      // If a user is already authenticated, sign them out first to avoid
+      // "UserAlreadyAuthenticatedException" errors from Amplify.
+      try {
+        await getCurrentUser();
+        await signOut();
+      } catch {
+        // getCurrentUser throws if no user is signed in; ignore in that case
+      }
+
       const { isSignedIn } = await signIn({
         username: email,
         password: password,
       });
-      
+
       if (isSignedIn) {
         await checkAuthStatus();
       }


### PR DESCRIPTION
## Summary
- avoid `UserAlreadyAuthenticatedException` from Amplify
- sign out any existing session before attempting login

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_684381bc7f508332a06930599113293e