### PR TITLE
Add team lead group to Amplify auth

### DIFF
--- a/packages/frontend/amplify/auth/resource.ts
+++ b/packages/frontend/amplify/auth/resource.ts
@@ -12,6 +12,8 @@ export const auth = defineAuth({
       verificationEmailBody: (createCode) => `Welcome to Miliare! Use this code to confirm your account: ${createCode()}`,
     },
   },
+  // User pool groups used throughout the app for authorization
+  groups: ["admin", "teamLead"],
   userAttributes: {
     // Standard attributes
     email: {


### PR DESCRIPTION
## Summary
- allow `admin` and `teamLead` auth groups in Amplify Gen 2 auth setup

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_6843b0fcb2d08332a58c9da82de4148d