### PR TITLE
Add missing UI primitives

### DIFF
--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div data-slot="card-title" className={cn('leading-none font-semibold', className)} {...props} />
+  );
+}
+
+export function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div data-slot="card-description" className={cn('text-muted-foreground text-sm', className)} {...props} />
+  );
+}
+
+export function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  );
+}
+
+export function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
+}
+
+export function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div data-slot="card-footer" className={cn('flex items-center px-6 [.border-t]:pt-6', className)} {...props} />
+  );
+}

--- a/packages/frontend/src/components/ui/Checkbox.tsx
+++ b/packages/frontend/src/components/ui/Checkbox.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export function Checkbox({ className, ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      type="checkbox"
+      className={cn('rounded border-gray-300 text-primary focus:ring-primary', className)}
+      {...props}
+    />
+  );
+}

--- a/packages/frontend/src/components/ui/DropdownMenu.tsx
+++ b/packages/frontend/src/components/ui/DropdownMenu.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { cn } from '../../utils/cn';
+
+type DropdownState = { open: boolean; setOpen: (v: boolean) => void };
+const DropdownContext = createContext<DropdownState | null>(null);
+
+export function DropdownMenu({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <DropdownContext.Provider value={{ open, setOpen }}>
+      <div className="relative inline-block">{children}</div>
+    </DropdownContext.Provider>
+  );
+}
+
+export function DropdownMenuTrigger({ children, className }: React.HTMLAttributes<HTMLButtonElement>) {
+  const ctx = useContext(DropdownContext);
+  if (!ctx) throw new Error('DropdownMenuTrigger must be inside DropdownMenu');
+  return (
+    <button onClick={() => ctx.setOpen(!ctx.open)} className={cn(className)}>
+      {children}
+    </button>
+  );
+}
+
+export function DropdownMenuContent({ children, className }: React.HTMLAttributes<HTMLDivElement>) {
+  const ctx = useContext(DropdownContext)!;
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!ctx.open) return;
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        ctx.setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [ctx]);
+  if (!ctx.open) return null;
+  return (
+    <div ref={ref} className={cn('absolute right-0 mt-2 w-48 rounded-md border bg-white shadow-md py-1', className)}>
+      {children}
+    </div>
+  );
+}
+
+export function DropdownMenuItem({ children, onSelect, className }: { children: React.ReactNode; onSelect?: () => void; className?: string }) {
+  const ctx = useContext(DropdownContext);
+  return (
+    <div
+      onClick={() => {
+        onSelect?.();
+        ctx?.setOpen(false);
+      }}
+      className={cn('cursor-pointer px-3 py-2 text-sm hover:bg-gray-100', className)}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DropdownMenuLabel({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('px-3 py-2 text-xs font-medium text-gray-500', className)}>{children}</div>;
+}
+
+export function DropdownMenuSeparator({ className }: { className?: string }) {
+  return <div className={cn('my-1 h-px bg-gray-200', className)} />;
+}

--- a/packages/frontend/src/components/ui/Form.tsx
+++ b/packages/frontend/src/components/ui/Form.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Controller, FormProvider, useFormContext, type ControllerProps, type FieldPath, type FieldValues } from 'react-hook-form';
+import { cn } from '../../utils/cn';
+
+export const Form = FormProvider;
+
+export function FormField<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>(props: ControllerProps<TFieldValues, TName>) {
+  return <Controller {...props} />;
+}
+
+export function FormItem({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('grid gap-2', className)} {...props} />;
+}
+
+export function FormLabel({ className, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) {
+  return <label className={cn('text-sm font-medium', className)} {...props} />;
+}
+
+export function FormControl({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn(className)} {...props} />;
+}
+
+export function FormMessage({ className, children, ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
+  const { formState } = useFormContext();
+  if (!children && !formState.errors) return null;
+  return (
+    <p className={cn('text-sm text-red-600', className)} {...props}>
+      {children}
+    </p>
+  );
+}

--- a/packages/frontend/src/components/ui/Label.tsx
+++ b/packages/frontend/src/components/ui/Label.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export function Label({ className, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) {
+  return <label className={cn('text-sm font-medium', className)} {...props} />;
+}

--- a/packages/frontend/src/components/ui/Table.tsx
+++ b/packages/frontend/src/components/ui/Table.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+export function Table({ className, ...props }: React.TableHTMLAttributes<HTMLTableElement>) {
+  return <table className={cn('w-full text-sm', className)} {...props} />;
+}
+
+export function TableHeader({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <thead className={cn('bg-gray-50', className)} {...props} />;
+}
+
+export function TableBody({ className, ...props }: React.HTMLAttributes<HTMLTableSectionElement>) {
+  return <tbody className={cn(className)} {...props} />;
+}
+
+export function TableRow({ className, ...props }: React.HTMLAttributes<HTMLTableRowElement>) {
+  return <tr className={cn('border-b last:border-0', className)} {...props} />;
+}
+
+export function TableHead({ className, ...props }: React.HTMLAttributes<HTMLTableCellElement>) {
+  return <th className={cn('px-3 py-2 text-left font-medium', className)} {...props} />;
+}
+
+export function TableCell({ className, ...props }: React.HTMLAttributes<HTMLTableCellElement>) {
+  return <td className={cn('px-3 py-2', className)} {...props} />;
+}
+
+export function TableCaption({ className, ...props }: React.HTMLAttributes<HTMLTableCaptionElement>) {
+  return <caption className={cn('mt-4 text-sm text-gray-500', className)} {...props} />;
+}


### PR DESCRIPTION
## Summary
- add card, checkbox, dropdown menu, form, label and table UI components

## Testing
- `pnpm run frontend:lint`

------
https://chatgpt.com/codex/tasks/task_b_6844f64e3f508332bb97ff539b563fe8