### PR TITLE
Fix dashboard placeholders

### DIFF
--- a/packages/frontend/src/components/EarningsOverviewChart.tsx
+++ b/packages/frontend/src/components/EarningsOverviewChart.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  LineElement,
+  PointElement,
+  LinearScale,
+  CategoryScale,
+  Tooltip,
+} from 'chart.js';
+import type { Earnings } from '../data/dashboardData';
+
+ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip);
+
+interface Props {
+  data: Earnings[];
+}
+
+export function EarningsOverviewChart({ data }: Props) {
+  const chartData = React.useMemo(() => ({
+    labels: data.map(d => d.month),
+    datasets: [
+      {
+        label: 'Earnings',
+        data: data.map(d => d.earnings),
+        borderColor: '#1e40af',
+        backgroundColor: 'rgba(30,64,175,0.3)',
+        tension: 0.4,
+        fill: true,
+      },
+    ],
+  }), [data]);
+
+  const options = React.useMemo(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: { tooltip: { intersect: false } },
+    scales: { y: { beginAtZero: true } },
+  }), []);
+
+  return (
+    <div className="h-64">
+      <Line data={chartData} options={options} />
+    </div>
+  );
+}

--- a/packages/frontend/src/data/dashboardData.ts
+++ b/packages/frontend/src/data/dashboardData.ts
@@ -1,0 +1,172 @@
+export interface SummaryMetric {
+  label: string;
+  value: string;
+  change: string;
+  changeType: 'positive' | 'negative' | 'neutral';
+  description: string;
+  icon: string;
+  gradient: string;
+  bgColor: string;
+  iconColor: string;
+}
+
+export interface PendingReferral {
+  date: string;
+  client: string;
+  company: string;
+  status: string;
+  amount: string;
+  statusColor: string;
+}
+
+export interface RecentPayment {
+  company: string;
+  date: string;
+  amount: string;
+  status: string;
+  initials: string;
+  bgColor: string;
+}
+
+export interface Earnings { month: string; earnings: number }
+
+export const summary: SummaryMetric[] = [
+  {
+    label: 'Total Earnings',
+    value: '$14,250.75',
+    change: '+12.3%',
+    changeType: 'positive',
+    description: 'vs last month',
+    icon: 'DollarSign',
+    gradient: 'from-blue-600 to-blue-700',
+    bgColor: 'bg-blue-50',
+    iconColor: 'text-blue-600'
+  },
+  {
+    label: 'Pending Commissions',
+    value: '$2,430.50',
+    change: '3 pending',
+    changeType: 'neutral',
+    description: 'awaiting payout',
+    icon: 'Clock',
+    gradient: 'from-amber-500 to-amber-600',
+    bgColor: 'bg-amber-50',
+    iconColor: 'text-amber-600'
+  },
+  {
+    label: 'Total Referrals',
+    value: '35',
+    change: '+8',
+    changeType: 'positive',
+    description: 'this month',
+    icon: 'Users',
+    gradient: 'from-green-600 to-green-700',
+    bgColor: 'bg-green-50',
+    iconColor: 'text-green-600'
+  },
+  {
+    label: 'Success Rate',
+    value: '80%',
+    change: '+5%',
+    changeType: 'positive',
+    description: 'vs industry avg',
+    icon: 'TrendingUp',
+    gradient: 'from-purple-600 to-purple-700',
+    bgColor: 'bg-purple-50',
+    iconColor: 'text-purple-600'
+  },
+];
+
+export const pendingReferrals: PendingReferral[] = [
+  {
+    date: 'Jun 27, 2023',
+    client: 'John Smith',
+    company: 'Prime Corporate Services',
+    status: 'In Progress',
+    amount: '$1,250',
+    statusColor: 'bg-amber-100 text-amber-800'
+  },
+  {
+    date: 'Jun 24, 2023',
+    client: 'Sarah Johnson',
+    company: 'Sunny Hill Financial',
+    status: 'In Progress',
+    amount: '$945',
+    statusColor: 'bg-amber-100 text-amber-800'
+  },
+  {
+    date: 'Jun 19, 2023',
+    client: 'Michael Brown',
+    company: 'Impact Health Sharing',
+    status: 'In Review',
+    amount: '$1,750',
+    statusColor: 'bg-blue-100 text-blue-800'
+  },
+];
+
+export const recentPayments: RecentPayment[] = [
+  {
+    company: 'Sunny Hill Financial',
+    date: 'Jun 14, 2023',
+    amount: '$1,250.50',
+    status: 'Paid',
+    initials: 'SH',
+    bgColor: 'bg-blue-600'
+  },
+  {
+    company: 'Prime Corporate Services',
+    date: 'May 19, 2023',
+    amount: '$945.25',
+    status: 'Paid',
+    initials: 'PC',
+    bgColor: 'bg-green-600'
+  },
+  {
+    company: 'ANCO Insurance',
+    date: 'Apr 9, 2023',
+    amount: '$1,750.00',
+    status: 'Paid',
+    initials: 'AN',
+    bgColor: 'bg-purple-600'
+  },
+  {
+    company: 'Summit Business Syndicate',
+    date: 'Mar 4, 2023',
+    amount: '$830.00',
+    status: 'Paid',
+    initials: 'SB',
+    bgColor: 'bg-amber-600'
+  },
+];
+
+export const earningsData6Months: Earnings[] = [
+  { month: 'Jan', earnings: 2000 },
+  { month: 'Feb', earnings: 2500 },
+  { month: 'Mar', earnings: 3000 },
+  { month: 'Apr', earnings: 3500 },
+  { month: 'May', earnings: 2800 },
+  { month: 'Jun', earnings: 2950 },
+];
+
+export const earningsData12Months: Earnings[] = [
+  { month: 'Jul', earnings: 3100 },
+  { month: 'Aug', earnings: 3300 },
+  { month: 'Sep', earnings: 3400 },
+  { month: 'Oct', earnings: 3600 },
+  { month: 'Nov', earnings: 3700 },
+  { month: 'Dec', earnings: 3900 },
+  ...earningsData6Months,
+].slice(-12);
+
+export const earningsDataYear: Earnings[] = [
+  ...earningsData12Months,
+];
+
+export const chartConfig = {
+  earnings: {
+    label: 'Earnings',
+    color: '#1e40af',
+  },
+};
+
+export const earningsData = earningsData6Months;

--- a/packages/frontend/src/data/teamData.ts
+++ b/packages/frontend/src/data/teamData.ts
@@ -1,0 +1,27 @@
+export interface TeamMember {
+  name: string;
+  title: string;
+  bio: string;
+  email: string;
+}
+
+export const team: TeamMember[] = [
+  {
+    name: 'John Doe',
+    title: 'Chief Executive Officer',
+    bio: 'John oversees strategic direction and operations at Miliare.',
+    email: 'john.doe@example.com',
+  },
+  {
+    name: 'Jane Smith',
+    title: 'Chief Technology Officer',
+    bio: 'Jane leads our technology strategy and product development.',
+    email: 'jane.smith@example.com',
+  },
+  {
+    name: 'Alex Johnson',
+    title: 'Head of Operations',
+    bio: 'Alex ensures smooth day-to-day operations across the company.',
+    email: 'alex.johnson@example.com',
+  },
+];

--- a/packages/frontend/src/layouts/DashboardLayout.tsx
+++ b/packages/frontend/src/layouts/DashboardLayout.tsx
@@ -11,17 +11,24 @@ import {
   User,
   Users,
   Bell,
-  ChevronDown,
   Settings,
+  ChevronDown,
 } from 'lucide-react';
 import { Button } from '../components/ui/Button';
 import { toast } from '../components/ui/Toaster';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '../components/ui/DropdownMenu';
 
 const DashboardLayout = () => {
   const { user, logout } = useAuth();
   const navigate = useNavigate();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   
   const handleLogout = () => {
     logout();
@@ -33,9 +40,6 @@ const DashboardLayout = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
   };
   
-  const toggleProfileMenu = () => {
-    setIsProfileMenuOpen(!isProfileMenuOpen);
-  };
   
   const closeMobileMenu = () => {
     setIsMobileMenuOpen(false);
@@ -98,50 +102,31 @@ const DashboardLayout = () => {
               </div>
               
               {/* Profile dropdown */}
-              <div className="ml-3 relative">
-                <div>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
                   <Button
                     variant="ghost"
-                    onClick={toggleProfileMenu}
                     className="flex items-center max-w-xs text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
                   >
                     <span className="mr-2">{user?.name}</span>
                     <ChevronDown className="h-4 w-4" />
                   </Button>
-                </div>
-                
-                {isProfileMenuOpen && (
-                  <div className="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5">
-                    <button
-                      className="w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                      onClick={() => {
-                        setIsProfileMenuOpen(false);
-                        // Navigate to profile page when implemented
-                      }}
-                    >
-                      <User className="inline-block mr-2 h-4 w-4" />
-                      Your Profile
-                    </button>
-                    <button
-                      className="w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                      onClick={() => {
-                        setIsProfileMenuOpen(false);
-                        // Navigate to settings page when implemented
-                      }}
-                    >
-                      <Settings className="inline-block mr-2 h-4 w-4" />
-                      Settings
-                    </button>
-                    <button
-                      className="w-full text-left block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-                      onClick={handleLogout}
-                    >
-                      <LogOut className="inline-block mr-2 h-4 w-4" />
-                      Sign out
-                    </button>
-                  </div>
-                )}
-              </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="mt-2 w-48">
+                  <DropdownMenuLabel>My Account</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem>
+                    <User className="inline-block mr-2 h-4 w-4" /> Your Profile
+                  </DropdownMenuItem>
+                  <DropdownMenuItem>
+                    <Settings className="inline-block mr-2 h-4 w-4" /> Settings
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onSelect={handleLogout}>
+                    <LogOut className="inline-block mr-2 h-4 w-4" /> Sign out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
             
             {/* Mobile menu button */}

--- a/packages/frontend/src/pages/dashboard/BusinessPage.tsx
+++ b/packages/frontend/src/pages/dashboard/BusinessPage.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
-  BarChart3,
   TrendingUp,
   Clock,
   DollarSign,
@@ -9,27 +8,24 @@ import {
 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Link } from 'react-router-dom';
+import {
+  summary,
+  pendingReferrals,
+  recentPayments,
+  earningsData6Months,
+  earningsData12Months,
+  earningsDataYear,
+} from '../../data/dashboardData';
+import { EarningsOverviewChart } from '../../components/EarningsOverviewChart';
 
 const BusinessPage = () => {
-  
-  // Mock data for demonstration
-  const totalEarnings = 14250.75;
-  const pendingCommissions = 2430.50;
-  const referralsCount = 35;
-  const successfulReferrals = 28;
-  
-  const recentPayments = [
-    { id: 1, date: '2023-06-15', amount: 1250.50, status: 'Paid', company: 'Sunny Hill Financial' },
-    { id: 2, date: '2023-05-20', amount: 945.25, status: 'Paid', company: 'Prime Corporate Services' },
-    { id: 3, date: '2023-04-10', amount: 1750.00, status: 'Paid', company: 'ANCO Insurance' },
-    { id: 4, date: '2023-03-05', amount: 830.00, status: 'Paid', company: 'Summit Business Syndicate' },
-  ];
-  
-  const pendingReferrals = [
-    { id: 1, date: '2023-06-28', client: 'John Smith', company: 'Prime Corporate Services', status: 'In Progress', estimatedCommission: 850.00 },
-    { id: 2, date: '2023-06-25', client: 'Sarah Johnson', company: 'Sunny Hill Financial', status: 'In Progress', estimatedCommission: 1280.50 },
-    { id: 3, date: '2023-06-20', client: 'Michael Brown', company: 'Impact Health Sharing', status: 'In Review', estimatedCommission: 300.00 },
-  ];
+  const [period, setPeriod] = useState('Last 6 months');
+
+  const earningsMap: Record<string, typeof earningsData6Months> = {
+    'Last 6 months': earningsData6Months,
+    'Last 12 months': earningsData12Months,
+    'Year to date': earningsDataYear,
+  };
   
   return (
     <div className="space-y-8">
@@ -39,77 +35,44 @@ const BusinessPage = () => {
           Track your referrals, earnings, and pending commissions
         </p>
       </div>
-      
+
       {/* Stats overview */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-blue-100 text-primary">
-              <DollarSign className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Total Earnings</p>
-              <p className="text-2xl font-semibold text-gray-900">${totalEarnings.toLocaleString()}</p>
-            </div>
-          </div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-green-100 text-success">
-              <Clock className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Pending Commissions</p>
-              <p className="text-2xl font-semibold text-gray-900">${pendingCommissions.toLocaleString()}</p>
+        {summary.map(metric => (
+          <div key={metric.label} className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
+            <div className="flex items-center">
+              <div className={`p-3 rounded-full ${metric.bgColor} ${metric.iconColor}`}>{
+                metric.icon === 'DollarSign' ? <DollarSign className="h-6 w-6" /> :
+                metric.icon === 'Clock' ? <Clock className="h-6 w-6" /> :
+                metric.icon === 'Users' ? <Users className="h-6 w-6" /> :
+                <TrendingUp className="h-6 w-6" />
+              }</div>
+              <div className="ml-4">
+                <p className="text-sm font-medium text-gray-500">{metric.label}</p>
+                <p className="text-2xl font-semibold text-gray-900">{metric.value}</p>
+              </div>
             </div>
           </div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-purple-100 text-purple-600">
-              <Users className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Total Referrals</p>
-              <p className="text-2xl font-semibold text-gray-900">{referralsCount}</p>
-            </div>
-          </div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-orange-100 text-orange-600">
-              <TrendingUp className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Success Rate</p>
-              <p className="text-2xl font-semibold text-gray-900">{Math.round((successfulReferrals / referralsCount) * 100)}%</p>
-            </div>
-          </div>
-        </div>
+        ))}
       </div>
       
-      {/* Chart/Graph placeholder */}
+      {/* Earnings chart */}
       <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-lg font-semibold text-gray-900">Earnings Overview</h2>
           <div>
-            <select className="py-1 px-3 border border-gray-300 rounded-md text-sm">
+            <select
+              className="py-1 px-3 border border-gray-300 rounded-md text-sm"
+              value={period}
+              onChange={e => setPeriod(e.target.value)}
+            >
               <option>Last 6 months</option>
               <option>Last 12 months</option>
               <option>Year to date</option>
             </select>
           </div>
         </div>
-        
-        <div className="flex items-center justify-center h-64 bg-gray-50 rounded-lg border border-dashed border-gray-300">
-          <div className="text-center">
-            <BarChart3 className="mx-auto h-12 w-12 text-gray-400" />
-            <p className="mt-2 text-sm text-gray-500">Earnings visualization will appear here</p>
-          </div>
-        </div>
+        <EarningsOverviewChart data={earningsMap[period]} />
       </div>
       
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
@@ -154,16 +117,14 @@ const BusinessPage = () => {
                       {referral.company}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                        referral.status === 'In Progress' 
-                          ? 'bg-yellow-100 text-yellow-800' 
-                          : 'bg-blue-100 text-blue-800'
-                      }`}>
+                      <span
+                        className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${referral.statusColor}`}
+                      >
                         {referral.status}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      ${referral.estimatedCommission.toLocaleString()}
+                      {referral.amount}
                     </td>
                   </tr>
                 ))}
@@ -180,17 +141,17 @@ const BusinessPage = () => {
           </div>
           
           <div className="space-y-4">
-            {recentPayments.map((payment) => (
-              <div key={payment.id} className="flex items-center p-4 bg-gray-50 rounded-lg">
+            {recentPayments.map((payment, i) => (
+              <div key={i} className="flex items-center p-4 bg-gray-50 rounded-lg">
                 <div className="flex-shrink-0">
                   <CreditCard className="h-8 w-8 text-gray-400" />
                 </div>
                 <div className="ml-4 flex-1">
                   <p className="text-sm font-medium text-gray-900">{payment.company}</p>
-                  <p className="text-xs text-gray-500">{new Date(payment.date).toLocaleDateString()}</p>
+                  <p className="text-xs text-gray-500">{payment.date}</p>
                 </div>
                 <div className="ml-4">
-                  <p className="text-sm font-semibold text-gray-900">${payment.amount.toLocaleString()}</p>
+                  <p className="text-sm font-semibold text-gray-900">{payment.amount}</p>
                   <p className="text-xs font-medium text-green-600">{payment.status}</p>
                 </div>
               </div>

--- a/packages/frontend/src/pages/dashboard/TeamPage.tsx
+++ b/packages/frontend/src/pages/dashboard/TeamPage.tsx
@@ -1,220 +1,24 @@
 import React from 'react';
-import {
-  BarChart3,
-  TrendingUp,
-  Clock,
-  DollarSign,
-  Users,
-  CreditCard,
-} from 'lucide-react';
-import { Button } from '../../components/ui/Button';
-import { Link } from 'react-router-dom';
+import { team } from '../../data/teamData';
 
 const TeamPage = () => {
-  // Mock aggregated team data for demonstration
-  const totalEarnings = 48250.75;
-  const pendingCommissions = 5430.5;
-  const referralsCount = 135;
-  const successfulReferrals = 98;
-  
-  const recentPayments = [
-    { id: 1, date: '2023-06-15', amount: 1250.50, status: 'Paid', company: 'Sunny Hill Financial' },
-    { id: 2, date: '2023-05-20', amount: 945.25, status: 'Paid', company: 'Prime Corporate Services' },
-    { id: 3, date: '2023-04-10', amount: 1750.00, status: 'Paid', company: 'ANCO Insurance' },
-    { id: 4, date: '2023-03-05', amount: 830.00, status: 'Paid', company: 'Summit Business Syndicate' },
-  ];
-  
-  const pendingReferrals = [
-    { id: 1, date: '2023-06-28', client: 'John Smith', company: 'Prime Corporate Services', status: 'In Progress', estimatedCommission: 850.00 },
-    { id: 2, date: '2023-06-25', client: 'Sarah Johnson', company: 'Sunny Hill Financial', status: 'In Progress', estimatedCommission: 1280.50 },
-    { id: 3, date: '2023-06-20', client: 'Michael Brown', company: 'Impact Health Sharing', status: 'In Review', estimatedCommission: 300.00 },
-  ];
-  
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">Your Team Dashboard</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Aggregate performance of your team members
-        </p>
+        <h1 className="text-2xl font-bold text-gray-900">Our Team</h1>
+        <p className="mt-1 text-sm text-gray-500">Meet the people behind Miliare.</p>
       </div>
-      
-      {/* Stats overview */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-blue-100 text-primary">
-              <DollarSign className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Total Earnings</p>
-              <p className="text-2xl font-semibold text-gray-900">${totalEarnings.toLocaleString()}</p>
-            </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {team.map(member => (
+          <div key={member.email} className="bg-white rounded-lg shadow-sm border border-gray-100 p-6">
+            <h2 className="text-lg font-semibold text-gray-900">{member.name}</h2>
+            <p className="text-primary font-medium mb-2">{member.title}</p>
+            <p className="text-gray-600 text-sm mb-4">{member.bio}</p>
+            <a href={`mailto:${member.email}`} className="text-primary hover:underline text-sm">
+              {member.email}
+            </a>
           </div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-green-100 text-success">
-              <Clock className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Pending Commissions</p>
-              <p className="text-2xl font-semibold text-gray-900">${pendingCommissions.toLocaleString()}</p>
-            </div>
-          </div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-purple-100 text-purple-600">
-              <Users className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Total Referrals</p>
-              <p className="text-2xl font-semibold text-gray-900">{referralsCount}</p>
-            </div>
-          </div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex items-center">
-            <div className="p-3 rounded-full bg-orange-100 text-orange-600">
-              <TrendingUp className="h-6 w-6" />
-            </div>
-            <div className="ml-4">
-              <p className="text-sm font-medium text-gray-500">Success Rate</p>
-              <p className="text-2xl font-semibold text-gray-900">{Math.round((successfulReferrals / referralsCount) * 100)}%</p>
-            </div>
-          </div>
-        </div>
-      </div>
-      
-      {/* Chart/Graph placeholder */}
-      <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">Earnings Overview</h2>
-          <div>
-            <select className="py-1 px-3 border border-gray-300 rounded-md text-sm">
-              <option>Last 6 months</option>
-              <option>Last 12 months</option>
-              <option>Year to date</option>
-            </select>
-          </div>
-        </div>
-        
-        <div className="flex items-center justify-center h-64 bg-gray-50 rounded-lg border border-dashed border-gray-300">
-          <div className="text-center">
-            <BarChart3 className="mx-auto h-12 w-12 text-gray-400" />
-            <p className="mt-2 text-sm text-gray-500">Earnings visualization will appear here</p>
-          </div>
-        </div>
-      </div>
-      
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        {/* Pending Referrals */}
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Pending Referrals</h2>
-            <Button variant="outline" size="sm">View All</Button>
-          </div>
-          
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-gray-200">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Date
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Client
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Company
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    Est. Commission
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-gray-200">
-                {pendingReferrals.map((referral) => (
-                  <tr key={referral.id}>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {new Date(referral.date).toLocaleDateString()}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                      {referral.client}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      {referral.company}
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm">
-                      <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                        referral.status === 'In Progress' 
-                          ? 'bg-yellow-100 text-yellow-800' 
-                          : 'bg-blue-100 text-blue-800'
-                      }`}>
-                        {referral.status}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                      ${referral.estimatedCommission.toLocaleString()}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-        
-        {/* Recent Payments */}
-        <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-100">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Recent Payments</h2>
-            <Button variant="outline" size="sm">Payment History</Button>
-          </div>
-          
-          <div className="space-y-4">
-            {recentPayments.map((payment) => (
-              <div key={payment.id} className="flex items-center p-4 bg-gray-50 rounded-lg">
-                <div className="flex-shrink-0">
-                  <CreditCard className="h-8 w-8 text-gray-400" />
-                </div>
-                <div className="ml-4 flex-1">
-                  <p className="text-sm font-medium text-gray-900">{payment.company}</p>
-                  <p className="text-xs text-gray-500">{new Date(payment.date).toLocaleDateString()}</p>
-                </div>
-                <div className="ml-4">
-                  <p className="text-sm font-semibold text-gray-900">${payment.amount.toLocaleString()}</p>
-                  <p className="text-xs font-medium text-green-600">{payment.status}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-      
-      {/* CTA section */}
-      <div className="bg-primary rounded-lg shadow-md overflow-hidden">
-        <div className="px-6 py-8 md:p-8 md:flex md:items-center md:justify-between">
-          <div className="text-center md:text-left">
-            <h2 className="text-xl font-bold text-white">Ready to increase your earnings?</h2>
-            <p className="mt-1 text-primary-foreground text-opacity-90">
-              Refer clients to our strategic partners and earn commissions.
-            </p>
-          </div>
-          <div className="mt-6 md:mt-0">
-            <Link to="/dashboard/refer">
-              <Button variant="outline" className="w-full md:w-auto bg-white text-primary hover:bg-gray-100">
-                Make a Referral
-              </Button>
-            </Link>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add chart component for earnings overview
- provide sample dashboard data and team data
- render real metrics on business dashboard
- use dropdown menu component for profile actions
- show team members instead of stub dashboard

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test` *(fails: HTMLCanvasElement.getContext not implemented)*

------
https://chatgpt.com/codex/tasks/task_b_6845011209608332be8985230ae8a29a