### PR TITLE
Add referral modal form

### DIFF
--- a/packages/frontend/src/components/ReferralFormModal.tsx
+++ b/packages/frontend/src/components/ReferralFormModal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+import { Modal } from './ui/Modal';
+import { toast } from './ui/Toaster';
+
+const referralSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Please enter a valid email address'),
+  phone: z.string().min(10, 'Please enter a valid phone number'),
+  type: z.string().min(1, 'Referral type is required'),
+  value: z.string().min(1, 'Referral value is required'),
+});
+
+type ReferralFormValues = z.infer<typeof referralSchema>;
+
+interface ReferralFormModalProps {
+  open: boolean;
+  onClose: () => void;
+  partnerName?: string;
+}
+
+const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ open, onClose, partnerName }) => {
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<ReferralFormValues>({
+    resolver: zodResolver(referralSchema),
+  });
+
+  const onSubmit = (formData: ReferralFormValues) => {
+    toast.success('Referral submitted', `Thank you for referring ${formData.name}.`);
+    reset();
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title={partnerName ? `Refer to ${partnerName}` : 'New Referral'}>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <Input label="Name" {...register('name')} error={errors.name?.message} />
+        <Input label="Email" type="email" {...register('email')} error={errors.email?.message} />
+        <Input label="Phone" type="tel" {...register('phone')} error={errors.phone?.message} />
+        <Input label="Type of Referral" {...register('type')} error={errors.type?.message} />
+        <Input label="Value of Referral" type="number" {...register('value')} error={errors.value?.message} />
+        <div className="flex justify-end">
+          <Button type="submit">Submit</Button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default ReferralFormModal;

--- a/packages/frontend/src/components/ui/Modal.tsx
+++ b/packages/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+import { X } from 'lucide-react';
+import { cn } from '../../utils/cn';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export const Modal: React.FC<ModalProps> = ({ open, onClose, title, className, children }) => {
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className={cn('relative bg-white rounded-lg shadow-lg w-full max-w-md p-6', className)}>
+        <button
+          className="absolute right-3 top-3 rounded-md p-1 text-gray-500 hover:bg-gray-100"
+          onClick={onClose}
+        >
+          <X className="h-4 w-4" />
+        </button>
+        {title && <h2 className="mb-4 text-lg font-semibold text-gray-900">{title}</h2>}
+        {children}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/packages/frontend/src/pages/dashboard/PartnerDetailPage.tsx
+++ b/packages/frontend/src/pages/dashboard/PartnerDetailPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { 
   ArrowLeft, 
@@ -14,10 +14,12 @@ import {
 import { Button } from '../../components/ui/Button';
 import { partnersData } from '../../data/partnersData';
 import { toast } from '../../components/ui/Toaster';
+import ReferralFormModal from '../../components/ReferralFormModal';
 
 const PartnerDetailPage = () => {
   const { partnerId } = useParams<{ partnerId: string }>();
   const navigate = useNavigate();
+  const [showReferralModal, setShowReferralModal] = useState(false);
   
   const partner = useMemo(() => {
     return partnersData.find(p => p.id === partnerId);
@@ -145,17 +147,13 @@ const PartnerDetailPage = () => {
                 </Button>
               </a>
               
-              <a 
-                href={partner.referralUrl} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="inline-block"
+              <Button
+                className="w-full sm:w-auto flex items-center"
+                onClick={() => setShowReferralModal(true)}
               >
-                <Button className="w-full sm:w-auto flex items-center">
-                  <Send className="mr-2 h-4 w-4" />
-                  Refer a Client
-                </Button>
-              </a>
+                <Send className="mr-2 h-4 w-4" />
+                Refer a Client
+              </Button>
             </div>
           </div>
         </div>
@@ -285,19 +283,21 @@ const PartnerDetailPage = () => {
             </p>
           </div>
           <div className="mt-6 md:mt-0">
-            <a 
-              href={partner.referralUrl} 
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="inline-block"
+            <Button
+              variant="outline"
+              className="w-full md:w-auto bg-white text-primary hover:bg-gray-100"
+              onClick={() => setShowReferralModal(true)}
             >
-              <Button variant="outline" className="w-full md:w-auto bg-white text-primary hover:bg-gray-100">
-                Make a Referral Now
-              </Button>
-            </a>
+              Make a Referral Now
+            </Button>
           </div>
         </div>
       </div>
+      <ReferralFormModal
+        open={showReferralModal}
+        onClose={() => setShowReferralModal(false)}
+        partnerName={partner.name}
+      />
     </div>
   );
 };

--- a/packages/frontend/src/pages/dashboard/ReferPage.tsx
+++ b/packages/frontend/src/pages/dashboard/ReferPage.tsx
@@ -7,12 +7,14 @@ import {
 } from 'lucide-react';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
-import { partnersData } from '../../data/partnersData';
+import { partnersData, type Partner } from '../../data/partnersData';
 import { toast } from '../../components/ui/Toaster';
+import ReferralFormModal from '../../components/ReferralFormModal';
 
 const ReferPage = () => {
   const [search, setSearch] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedPartner, setSelectedPartner] = useState<Partner | null>(null);
   
   // Derive categories from partners data
   const categories = Array.from(
@@ -127,20 +129,14 @@ const ReferPage = () => {
                   Copy Link
                 </Button>
                 
-                <a 
-                  href={partner.referralUrl} 
-                  target="_blank" 
-                  rel="noopener noreferrer"
-                  className="inline-block"
+                <Button
+                  className="w-full flex items-center justify-center"
+                  size="sm"
+                  onClick={() => setSelectedPartner(partner)}
                 >
-                  <Button
-                    className="w-full flex items-center justify-center"
-                    size="sm"
-                  >
-                    <Send className="mr-1 h-4 w-4" />
-                    Refer Now
-                  </Button>
-                </a>
+                  <Send className="mr-1 h-4 w-4" />
+                  Refer Now
+                </Button>
               </div>
             </div>
           </div>
@@ -195,6 +191,13 @@ const ReferPage = () => {
           </div>
         </div>
       </div>
+      {selectedPartner && (
+        <ReferralFormModal
+          open={!!selectedPartner}
+          onClose={() => setSelectedPartner(null)}
+          partnerName={selectedPartner.name}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add reusable `Modal` component
- add `ReferralFormModal` for collecting referral info
- update Refer page to open modal instead of external link
- update Partner Detail page to use modal for referrals

## Testing
- `pnpm run frontend:lint`
- `pnpm run frontend:test`


------
https://chatgpt.com/codex/tasks/task_b_68478c7ea8b88329a483d4c1172efb66