### PR TITLE
Send referral form data to Zapier

### DIFF
--- a/packages/frontend/src/components/ReferralFormModal.tsx
+++ b/packages/frontend/src/components/ReferralFormModal.tsx
@@ -28,10 +28,31 @@ const ReferralFormModal: React.FC<ReferralFormModalProps> = ({ open, onClose, pa
     resolver: zodResolver(referralSchema),
   });
 
-  const onSubmit = (formData: ReferralFormValues) => {
-    toast.success('Referral submitted', `Thank you for referring ${formData.name}.`);
-    reset();
-    onClose();
+  const onSubmit = async (formData: ReferralFormValues) => {
+    try {
+      const response = await fetch(
+        'https://hooks.zapier.com/hooks/catch/16444537/uydvaog/',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(formData),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('Request failed');
+      }
+
+      toast.success(
+        'Referral submitted',
+        `Thank you for referring ${formData.name}.`
+      );
+      reset();
+      onClose();
+    } catch (err) {
+      console.error('Failed to send referral', err);
+      toast.error('Submission failed', 'Please try again later.');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- update referral modal submission to POST form data to Zapier webhook

## Testing
- `pnpm run frontend:lint` *(fails: Unexpected any in EarningsChart.tsx)*
- `pnpm run frontend:test`

------
https://chatgpt.com/codex/tasks/task_b_6847b8894aa08329b73235b0cb279d3a